### PR TITLE
Added core seeding logic + unit testing for iterator

### DIFF
--- a/internal/seeder/seed.go
+++ b/internal/seeder/seed.go
@@ -66,7 +66,7 @@ func (s *SeedService) insertFromIterator(it objectIterator) error {
 				break
 			}
 
-			return fmt.Errorf("Error retrieving iterator object: %v", err)
+			return fmt.Errorf("error retrieving iterator object: %v", err)
 		}
 
 		metadata := newMetadata(obj)

--- a/internal/seeder/seed.go
+++ b/internal/seeder/seed.go
@@ -4,7 +4,9 @@ import (
 	"context"
 
 	"cloud.google.com/go/storage"
+	"github.com/BrandonY/gcs-metadata-server/internal/model"
 	"github.com/BrandonY/gcs-metadata-server/internal/repo"
+	"google.golang.org/api/iterator"
 )
 
 type SeedService struct {
@@ -23,7 +25,52 @@ func NewSeedService(client *storage.Client, bucketId string, directoryRepo repo.
 	}
 }
 
+func newMetadata(obj *storage.ObjectAttrs) *model.Metadata {
+	return &model.Metadata{
+		Bucket:       obj.Bucket,
+		Name:         obj.Name,
+		Size:         obj.Size,
+		StorageClass: obj.StorageClass,
+		Created:      obj.Created,
+		Updated:      obj.Updated,
+	}
+
+}
+
+type objectIterator interface {
+	Next() (*storage.ObjectAttrs, error)
+}
+
 // Seed initiates the seeding process by traversing bucket and inserting into db
 func (s *SeedService) Start(ctx context.Context) error {
+	b := s.client.Bucket(s.bucketId)
+	if _, err := b.Attrs(ctx); err != nil {
+		return err
+	}
+
+	it := b.Objects(ctx, nil)
+	if err := s.insertFromIterator(it); err != nil {
+		return err
+	}
+	return nil
+}
+
+// insertFromIterator traverses iterator while inserting all containing items into db
+func (s *SeedService) insertFromIterator(it objectIterator) error {
+	for {
+		obj, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+
+		if err != nil {
+			return err
+		}
+
+		metadata := newMetadata(obj)
+
+		s.metadataRepo.Insert(metadata)
+		s.directoryRepo.UpsertParentDirs(metadata.Bucket, metadata.Name, metadata.Size, 1)
+	}
 	return nil
 }

--- a/internal/seeder/seed_test.go
+++ b/internal/seeder/seed_test.go
@@ -1,0 +1,120 @@
+package seeder
+
+import (
+	"testing"
+	"time"
+
+	"cloud.google.com/go/storage"
+	"github.com/BrandonY/gcs-metadata-server/internal/model"
+	"github.com/BrandonY/gcs-metadata-server/internal/repo"
+	"google.golang.org/api/iterator"
+)
+
+func TestReadFromIterator(t *testing.T) {
+	testCases := []struct {
+		name string
+		it   *testObjectIterator
+	}{
+		{
+			name: "Succeeds iterating through objects",
+			it: &testObjectIterator{
+				items: []*storage.ObjectAttrs{
+					{
+						Bucket:       "mock",
+						Name:         "mock",
+						Size:         1,
+						StorageClass: "mock",
+						Created:      time.Now(),
+						Updated:      time.Now(),
+					},
+					{
+						Bucket:       "mock",
+						Name:         "dir/mock",
+						Size:         1,
+						StorageClass: "mock",
+						Created:      time.Now(),
+						Updated:      time.Now(),
+					},
+				},
+			},
+		},
+		{
+			name: "Succeeds if iterator is empty",
+			it: &testObjectIterator{
+				items: []*storage.ObjectAttrs{},
+			},
+		},
+		{
+			name: "Does not return errors if item data is malformed",
+			it: &testObjectIterator{
+				items: []*storage.ObjectAttrs{
+					{
+						Bucket:       "mock",
+						Size:         -1,
+						StorageClass: "mock",
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockMetadataRepo := &mockMetadataRepository{}
+			mockDirRepo := &mockDirectoryRepository{}
+
+			s := &SeedService{
+				metadataRepo:  mockMetadataRepo,
+				directoryRepo: mockDirRepo,
+			}
+
+			err := s.insertFromIterator(tc.it)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if mockMetadataRepo.calls != len(tc.it.items) {
+				t.Errorf("Metadata Insert calls mismatch: got %d, want %d", mockMetadataRepo.calls, len(tc.it.items))
+			}
+
+			if mockDirRepo.calls != len(tc.it.items) {
+				t.Errorf("Directory Upsert calls mismatch: got %d, want %d", mockDirRepo.calls, len(tc.it.items))
+			}
+		})
+	}
+}
+
+type testObjectIterator struct {
+	items []*storage.ObjectAttrs
+	index int
+}
+
+func (t *testObjectIterator) Next() (*storage.ObjectAttrs, error) {
+	if t.index >= len(t.items) {
+		return nil, iterator.Done
+	}
+
+	obj := t.items[t.index]
+	t.index++
+	return obj, nil
+}
+
+type mockMetadataRepository struct {
+	repo.MetadataRepository
+	calls int
+}
+
+func (m *mockMetadataRepository) Insert(metadata *model.Metadata) error {
+	m.calls++
+	return nil
+}
+
+type mockDirectoryRepository struct {
+	repo.DirectoryRepository
+	calls int
+}
+
+func (d *mockDirectoryRepository) UpsertParentDirs(bucket string, objName string, newSize int64, newCount int64) error {
+	d.calls++
+	return nil
+}


### PR DESCRIPTION
The purpose of this PR is to add the core logic to seed all the data from a bucket using a single thread as well as unit testing for the iterator itself. This initial implementation is for demo purposes and will be upgraded to support multiple workers in the near future.

In order to make these changes future proof, I implemented a function that consumes an iterator which makes unit testing convenient and refactor-able when the time for optimization comes in.