### PR TITLE
Refactor UpsertParentDir

### DIFF
--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/api/router"
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/repo"
+	"github.com/jessevdk/go-flags"
+)
+
+type options struct {
+	Port        int    `short:"p" long:"port" description:"Port for API to listen on" required:"true"`
+	DatabaseUrl string `short:"d" long:"database-url" description:"Database URL in which to store metadata" required:"true"`
+}
+
+func main() {
+	var opts options
+	if _, err := flags.Parse(&opts); err != nil {
+		os.Exit(1)
+	}
+
+	// Connect database
+	ctx := context.Background()
+	db := repo.NewDatabase(opts.DatabaseUrl, 5)
+
+	if err := db.Connect(ctx); err != nil {
+		log.Fatalf("Error connecting to database: %v\n", err)
+	}
+	defer db.Close()
+
+	if exists, err := db.PingTable(); !exists || err != nil {
+		log.Fatalf("Database has not been initialized: %v\n", err)
+	}
+
+	// Start server
+	router := router.New(db)
+	server := http.Server{
+		Addr:    fmt.Sprintf(":%d", opts.Port),
+		Handler: router,
+	}
+
+	log.Println("Starting server on port", server.Addr)
+	if err := server.ListenAndServe(); err != nil {
+		log.Fatalf("Error in server: %v\n", err)
+	}
+}

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -17,6 +17,8 @@ type options struct {
 	DatabaseUrl string `short:"d" long:"database-url" description:"Database URL in which to store metadata" required:"true"`
 }
 
+const maxDbConnections = 5
+
 func main() {
 	var opts options
 	if _, err := flags.Parse(&opts); err != nil {
@@ -25,7 +27,7 @@ func main() {
 
 	// Connect database
 	ctx := context.Background()
-	db := repo.NewDatabase(opts.DatabaseUrl, 5)
+	db := repo.NewDatabase(opts.DatabaseUrl, maxDbConnections)
 
 	if err := db.Connect(ctx); err != nil {
 		log.Fatalf("Error connecting to database: %v\n", err)

--- a/cmd/seeder/main.go
+++ b/cmd/seeder/main.go
@@ -17,6 +17,8 @@ type options struct {
 	DatabaseUrl string `short:"d" long:"database-url" description:"Database URL in which to store metadata" required:"true"`
 }
 
+const maxDbConnections = 1
+
 func main() {
 	var opts options
 	if _, err := flags.Parse(&opts); err != nil {
@@ -29,7 +31,7 @@ func main() {
 
 	// Connect database
 	ctx := context.Background()
-	db := repo.NewDatabase(opts.DatabaseUrl, 1)
+	db := repo.NewDatabase(opts.DatabaseUrl, maxDbConnections)
 
 	if err := db.Connect(ctx); err != nil {
 		log.Fatalf("Error connecting to database: %v\n", err)

--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -1,0 +1,23 @@
+package handler
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/repo"
+)
+
+type ExploreHandler interface {
+	Explore(w http.ResponseWriter, r *http.Request)
+}
+
+type exploreHandler struct {
+	exploreRepo repo.ExploreRepository
+}
+
+func NewExploreHandler(exploreRepo repo.ExploreRepository) *exploreHandler {
+	return &exploreHandler{exploreRepo}
+}
+
+func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+}

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -1,0 +1,19 @@
+package router
+
+import (
+	"net/http"
+
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/api/handler"
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/repo"
+)
+
+func New(db *repo.Database) *http.ServeMux {
+	mux := http.NewServeMux()
+
+	exploreRepo := repo.NewExploreRepository(db)
+	exploreHandler := handler.NewExploreHandler(exploreRepo)
+
+	mux.HandleFunc("GET /explore/{path...}", exploreHandler.HandleExplore)
+
+	return mux
+}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -6,6 +6,7 @@ type Metadata struct {
 	Bucket       string    `json:"bucket" db:"bucket"`
 	Name         string    `json:"name" db:"name"`
 	Size         int64     `json:"size" db:"size"`
+	Count        int64     `json:"count" db:"count"`
 	StorageClass string    `json:"storage_class" db:"storage_class"`
 	Created      time.Time `json:"created" db:"created"`
 	Updated      time.Time `json:"updated" db:"updated"`

--- a/internal/repo/database.go
+++ b/internal/repo/database.go
@@ -86,3 +86,13 @@ func (db *Database) CreateTables() error {
 	}
 	return nil
 }
+
+// PingTable checks if database schema has been created by pinging metadata table
+func (db *Database) PingTable() (bool, error) {
+	var tableExists bool
+	if err := db.QueryRow(`SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type="table" AND name="metadata");`).Scan(&tableExists); err != nil {
+		return false, err
+	}
+
+	return tableExists, nil
+}

--- a/internal/repo/directory.go
+++ b/internal/repo/directory.go
@@ -60,7 +60,7 @@ func (d *Directory) UpsertParentDirs(bucket string, objName string, newSize int6
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer tx.Rollback() // no-op if commit succeeds
 
 	for {
 		if _, err = tx.Exec(query, bucket, dirName, newSize, newCount, getParentDir(dirName)); err != nil {

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -1,0 +1,23 @@
+package repo
+
+import (
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
+)
+
+type Explore struct {
+	*Database
+}
+
+type ExploreRepository interface {
+	GetPathContents(path, sort string) ([]*model.Metadata, error)
+}
+
+func NewExploreRepository(db *Database) ExploreRepository {
+	return &Explore{db}
+}
+
+// GetPath retrieves all directory contents of a given path
+// It excludes directories whose size is 0 
+func (e *Explore) GetPathContents(path, sort string) ([]*model.Metadata, error) {
+	return nil, nil
+}


### PR DESCRIPTION
This PR aims to refactor `UpsertParentDir()` in order to opt in for transactions handled by driver and rely less on string manipulation as well as removing the use of `fmt.Sprintf()` for inputting values which is unsafe. This results in safer and more readable code.

In the future we will want to join this function with `MetadataRepository.Insert()` as we should handle this operation in only one transaction to ensure data integrity