### PR TITLE
Implemented /explore/ endpoint for v1

### DIFF
--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -54,6 +54,7 @@ func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
 		Contents: contents,
 	}
 
+	w.Header().Set("Access-Control-Allow-Origin", "*") // TODO: remove in production
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, "Internal error", http.StatusInternalServerError)

--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -35,8 +35,8 @@ func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
 	sortString := r.URL.Query().Get("sort")
 	sort := repo.SortType(strings.ToLower(sortString))
 	if len(sort) == 0 {
-		sort = repo.Size
-	} else if sort != repo.Size && sort != repo.Count {
+		sort = repo.SortBySize
+	} else if sort != repo.SortBySize && sort != repo.SortByCount {
 		http.Error(w, "Invalid sort parameter, please use 'size' or 'count'", http.StatusBadRequest)
 		return
 	}

--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -1,8 +1,11 @@
 package handler
 
 import (
+	"encoding/json"
+	"log"
 	"net/http"
 
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
 	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/repo"
 )
 
@@ -19,5 +22,40 @@ func NewExploreHandler(exploreRepo repo.ExploreRepository) *exploreHandler {
 }
 
 func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusOK)
+	// Normalize path param
+	path := r.PathValue("path")
+	if len(path) == 0 {
+		path = "/"
+	} else if path[len(path)-1] != '/' {
+		path = path + "/"
+	}
+
+	// Validate sort query param
+	sort := r.URL.Query().Get("sort")
+	if len(sort) == 0 {
+		sort = "size"
+	} else if sort != "size" && sort != "count" {
+		http.Error(w, "Invalid sort parameter, please use 'size' or 'count'", http.StatusBadRequest)
+		return
+	}
+
+	contents, err := e.exploreRepo.GetPathContents(path, sort)
+	if err != nil {
+		log.Printf("Error retrieving path contents: %v", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+		return
+	}
+
+	response := struct {
+		Path     string            `json:"path"`
+		Contents []*model.Metadata `json:"contents"`
+	}{
+		Path:     r.PathValue("path"),
+		Contents: contents,
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(response); err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
 }

--- a/internal/api/handler/explore_test.go
+++ b/internal/api/handler/explore_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/repo"
 )
 
 func TestHandleExplore(t *testing.T) {
@@ -84,6 +85,6 @@ type mockExploreRepository struct {
 	pathContents []*model.Metadata
 }
 
-func (m *mockExploreRepository) GetPathContents(path, sort string) ([]*model.Metadata, error) {
+func (m *mockExploreRepository) GetPathContents(path string, sort repo.SortType) ([]*model.Metadata, error) {
 	return m.pathContents, nil
 }

--- a/internal/api/handler/explore_test.go
+++ b/internal/api/handler/explore_test.go
@@ -1,0 +1,89 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
+)
+
+func TestHandleExplore(t *testing.T) {
+	testCases := []struct {
+		name       string
+		path       string
+		sort       string
+		wantStatus int
+	}{
+		{
+			"Valid path with trailing slash",
+			"/mock/",
+			"",
+			http.StatusOK,
+		},
+		{
+			"Valid path without trailing slash",
+			"/mock",
+			"",
+			http.StatusOK,
+		},
+		{
+			"Root path",
+			"/",
+			"",
+			http.StatusOK,
+		},
+		{
+			"Empty path (root)",
+			"",
+			"",
+			http.StatusOK,
+		},
+		{
+			"Valid sort parameter 'count'",
+			"/mock/",
+			"count",
+			http.StatusOK,
+		},
+		{
+			"Invalid sort parameter",
+			"/mock/",
+			"invalid",
+			http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/explore/"+tc.path+"?sort="+tc.sort, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			mockRepo := &mockExploreRepository{
+				pathContents: []*model.Metadata{},
+			}
+
+			handler := NewExploreHandler(mockRepo)
+			handler.HandleExplore(rr, req)
+
+			if status := rr.Code; status != tc.wantStatus {
+				t.Errorf("status code mismatch: got %v want %v",
+					status, tc.wantStatus)
+			}
+
+			if tc.wantStatus != http.StatusOK {
+				return
+			}
+		})
+	}
+}
+
+type mockExploreRepository struct {
+	pathContents []*model.Metadata
+}
+
+func (m *mockExploreRepository) GetPathContents(path, sort string) ([]*model.Metadata, error) {
+	return m.pathContents, nil
+}

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -5,6 +5,7 @@ import "time"
 type Metadata struct {
 	Bucket       string    `json:"bucket" db:"bucket"`
 	Name         string    `json:"name" db:"name"`
+	Parent       string    `json:"parent" db:"parent"`
 	Size         int64     `json:"size" db:"size"`
 	Count        int64     `json:"count" db:"count"`
 	StorageClass string    `json:"storage_class" db:"storage_class"`

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -1,6 +1,8 @@
 package repo
 
 import (
+	"errors"
+
 	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
 )
 
@@ -17,7 +19,51 @@ func NewExploreRepository(db *Database) ExploreRepository {
 }
 
 // GetPath retrieves all directory contents of a given path
-// It excludes directories whose size is 0 
+// It excludes directories whose size is 0
 func (e *Explore) GetPathContents(path, sort string) ([]*model.Metadata, error) {
-	return nil, nil
+	if path == "/" {
+		path = "" // handle root
+	}
+
+	queryContent := `
+		SELECT name, size, count
+		FROM directory
+		WHERE
+			name LIKE $1 || '%/' AND
+			NOT name LIKE $1 || '%/%/' AND
+			NOT name LIKE '/' AND
+			size > 0
+		UNION ALL
+		SELECT name, size, 0 as count
+		FROM metadata
+		WHERE
+			name LIKE $1 || '%' AND
+			NOT name LIKE $1 || '%/%'
+	`
+
+	if sort == "count" {
+		queryContent += " ORDER BY count DESC"
+	} else if sort == "size" {
+		queryContent += " ORDER BY size DESC"
+	} else {
+		return nil, errors.New("invalid sort parameter")
+	}
+	queryContent += " LIMIT 100;"
+
+	rows, err := e.DB.Queryx(queryContent, path)
+	if err != nil {
+		return nil, errors.New("query error: " + err.Error())
+	}
+	defer rows.Close()
+
+	var pathContents []*model.Metadata
+	for rows.Next() {
+		var metadata model.Metadata
+		if err := rows.StructScan(&metadata); err != nil {
+			return nil, errors.New("scan error: " + err.Error())
+		}
+		pathContents = append(pathContents, &metadata)
+	}
+
+	return pathContents, nil
 }

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -9,8 +9,8 @@ import (
 type SortType string
 
 const (
-	Size  SortType = "size"
-	Count SortType = "count"
+	SortBySize  SortType = "size"
+	SortByCount SortType = "count"
 )
 
 type Explore struct {
@@ -50,9 +50,9 @@ func (e *Explore) GetPathContents(path string, sort SortType) ([]*model.Metadata
 			NOT name LIKE $1 || '%/%'
 	`
 
-	if sort == Count {
+	if sort == SortByCount {
 		queryContent += " ORDER BY count DESC"
-	} else if sort == Size {
+	} else if sort == SortBySize {
 		queryContent += " ORDER BY size DESC"
 	} else {
 		return nil, errors.New("invalid sort parameter")

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -6,12 +6,19 @@ import (
 	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
 )
 
+type SortType string
+
+const (
+	Size  SortType = "size"
+	Count SortType = "count"
+)
+
 type Explore struct {
 	*Database
 }
 
 type ExploreRepository interface {
-	GetPathContents(path, sort string) ([]*model.Metadata, error)
+	GetPathContents(path string, sort SortType) ([]*model.Metadata, error)
 }
 
 func NewExploreRepository(db *Database) ExploreRepository {
@@ -20,7 +27,7 @@ func NewExploreRepository(db *Database) ExploreRepository {
 
 // GetPath retrieves all directory contents of a given path including itself
 // It excludes directories whose size is 0
-func (e *Explore) GetPathContents(path, sort string) ([]*model.Metadata, error) {
+func (e *Explore) GetPathContents(path string, sort SortType) ([]*model.Metadata, error) {
 	if path == "/" {
 		path = "" // handle root
 	}
@@ -43,9 +50,9 @@ func (e *Explore) GetPathContents(path, sort string) ([]*model.Metadata, error) 
 			NOT name LIKE $1 || '%/%'
 	`
 
-	if sort == "count" {
+	if sort == Count {
 		queryContent += " ORDER BY count DESC"
-	} else if sort == "size" {
+	} else if sort == Size {
 		queryContent += " ORDER BY size DESC"
 	} else {
 		return nil, errors.New("invalid sort parameter")

--- a/internal/repo/explore_test.go
+++ b/internal/repo/explore_test.go
@@ -43,17 +43,18 @@ func TestGetPathContents(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		path      string
-		sort      string
-		want      []*model.Metadata
-		wantError bool
+		name    string
+		path    string
+		sort    string
+		want    []*model.Metadata
+		wantErr bool
 	}{
 		{
 			"Get root directory contents sorted by size",
 			"/",
 			"size",
 			[]*model.Metadata{
+				{Name: "/", Size: 14, Count: 4},
 				{Name: "file1", Size: 10, Count: 0},
 				{Name: "mock-1/", Size: 3, Count: 2},
 				{Name: "file2", Size: 1, Count: 0},
@@ -65,6 +66,7 @@ func TestGetPathContents(t *testing.T) {
 			"/",
 			"count",
 			[]*model.Metadata{
+				{Name: "/", Size: 14, Count: 4},
 				{Name: "mock-1/", Size: 3, Count: 2},
 				{Name: "file1", Size: 10, Count: 0},
 				{Name: "file2", Size: 1, Count: 0},
@@ -76,6 +78,7 @@ func TestGetPathContents(t *testing.T) {
 			"mock-1/",
 			"size",
 			[]*model.Metadata{
+				{Name: "mock-1/", Size: 3, Count: 2},
 				{Name: "mock-1//", Size: 2, Count: 1},
 				{Name: "mock-1/file3", Size: 1, Count: 0},
 			},
@@ -86,6 +89,7 @@ func TestGetPathContents(t *testing.T) {
 			"mock-1//",
 			"size",
 			[]*model.Metadata{
+				{Name: "mock-1//", Size: 2, Count: 1},
 				{Name: "mock-1//file4", Size: 2, Count: 0},
 			},
 			false,
@@ -110,13 +114,13 @@ func TestGetPathContents(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := exploreRepo.GetPathContents(tc.path, tc.sort)
 			if err != nil {
-				if tc.wantError {
+				if tc.wantErr {
 					return
 				}
 				t.Fatal(err)
 			}
 
-			if tc.wantError {
+			if tc.wantErr {
 				t.Fatalf("Expected error but did pass")
 			}
 
@@ -126,7 +130,15 @@ func TestGetPathContents(t *testing.T) {
 
 			for i := range got {
 				if got[i].Name != tc.want[i].Name {
-					t.Fatalf("Return order mismatch: got %v, want %v", got[i].Name, tc.want[i].Name)
+					t.Errorf("Return order mismatch: got %v, want %v", got[i].Name, tc.want[i].Name)
+				}
+
+				if got[i].Size != tc.want[i].Size {
+					t.Errorf("Return size mismatch: got %d, want %d", got[i].Size, tc.want[i].Size)
+				}
+
+				if got[i].Count != tc.want[i].Count {
+					t.Errorf("Return count mismatch: got %d, want %d", got[i].Count, tc.want[i].Count)
 				}
 			}
 		})

--- a/internal/repo/explore_test.go
+++ b/internal/repo/explore_test.go
@@ -112,7 +112,7 @@ func TestGetPathContents(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := exploreRepo.GetPathContents(tc.path, tc.sort)
+			got, err := exploreRepo.GetPathContents(tc.path, SortType(tc.sort))
 			if err != nil {
 				if tc.wantErr {
 					return

--- a/internal/repo/explore_test.go
+++ b/internal/repo/explore_test.go
@@ -1,0 +1,134 @@
+package repo
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
+)
+
+func TestGetPathContents(t *testing.T) {
+	db := NewDatabase(":memory:", 1)
+	db.Connect(context.Background())
+	defer db.Close()
+
+	if err := db.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.CreateTables(); err != nil {
+		t.Fatal(err)
+	}
+
+	exploreRepo := NewExploreRepository(db)
+	metadataRepo := NewMetadataRepository(db)
+	dirRepo := NewDirectoryRepository(db)
+
+	// Insert mock data
+	metadata := []model.Metadata{
+		{Bucket: "mock", Name: "file1", Size: 10, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "file2", Size: 1, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "mock-1/file3", Size: 1, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "mock-1//file4", Size: 2, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+	}
+
+	for _, m := range metadata {
+		if err := metadataRepo.Insert(&m); err != nil {
+			t.Fatal(err)
+		}
+		if err := dirRepo.UpsertParentDirs(m.Bucket, m.Name, m.Size, 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		name      string
+		path      string
+		sort      string
+		want      []*model.Metadata
+		wantError bool
+	}{
+		{
+			"Get root directory contents sorted by size",
+			"/",
+			"size",
+			[]*model.Metadata{
+				{Name: "file1", Size: 10, Count: 0},
+				{Name: "mock-1/", Size: 3, Count: 2},
+				{Name: "file2", Size: 1, Count: 0},
+			},
+			false,
+		},
+		{
+			"Get root directory contents sorted by count",
+			"/",
+			"count",
+			[]*model.Metadata{
+				{Name: "mock-1/", Size: 3, Count: 2},
+				{Name: "file1", Size: 10, Count: 0},
+				{Name: "file2", Size: 1, Count: 0},
+			},
+			false,
+		},
+		{
+			"Get nested directory contents sorted by size",
+			"mock-1/",
+			"size",
+			[]*model.Metadata{
+				{Name: "mock-1//", Size: 2, Count: 1},
+				{Name: "mock-1/file3", Size: 1, Count: 0},
+			},
+			false,
+		},
+		{
+			"Get trailing slash directory",
+			"mock-1//",
+			"size",
+			[]*model.Metadata{
+				{Name: "mock-1//file4", Size: 2, Count: 0},
+			},
+			false,
+		},
+		{
+			"Returns empty for non-existent directory",
+			"non-existent/",
+			"size",
+			nil,
+			false,
+		},
+		{
+			"Returns error for invalid sort parameter",
+			"/",
+			"invalid",
+			nil,
+			true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := exploreRepo.GetPathContents(tc.path, tc.sort)
+			if err != nil {
+				if tc.wantError {
+					return
+				}
+				t.Fatal(err)
+			}
+
+			if tc.wantError {
+				t.Fatalf("Expected error but did pass")
+			}
+
+			if len(got) != len(tc.want) {
+				t.Fatalf("Return count mismatch: got %d, want %d", len(got), len(tc.want))
+			}
+
+			for i := range got {
+				if got[i].Name != tc.want[i].Name {
+					t.Fatalf("Return order mismatch: got %v, want %v", got[i].Name, tc.want[i].Name)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
The purpose of this Pull Request is to implement the endpoint `/explore/{path...}` in which we will be able to retrieve directories results. It is a catch-all endpoint that will take anything after `/explore/` as a directory path within the bucket.

The `/explore/` endpoint also allows for query parameter `sort` in order to fetch results for either `count` or `size` (defaults to size)

For v1 purposes I am not including other information such as `storage_class` or `bucket` as schema will later be refactored to divide directory sizes by `storage_class`, allowing accurate estimation of pricing. This will help to have some data to further develop and push front-end service in a following PR.

### Endpoint details

`/explore/` retrieves all directory contents of a given path including itself
It excludes directories whose size is 0

Example request:
`/explore/images/may?sort=count`

Result example:
```
{
  [
    {
      "name": string,
      "parent": string, // only if item is directory
      "count": int, // only if item is directory
      "size": int,
    },
    ...
  ]
}
```
This representation is not 100% correct as it includes empty fields that are defined but not set in `model.Metadata`. In the future we should maybe refactor the `model.Metadata` struct to not hold created/updated values depending on the needs of the subscriber service.