### PR TITLE
Refactored logic + schema to divide size by classes and calculate prices

### DIFF
--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -25,23 +25,22 @@ func NewExploreHandler(exploreRepo repo.ExploreRepository) *exploreHandler {
 func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
 	// Normalize path param by adding slash(/) suffix if missing
 	path := r.PathValue("path")
-	if len(path) == 0 {
-		path = "/"
-	} else if !strings.HasSuffix(path, "/") {
+	if !strings.HasSuffix(path, "/") {
 		path = path + "/"
 	}
 
 	// Validate sort query param
 	sortString := r.URL.Query().Get("sort")
-	sort := repo.SortType(strings.ToLower(sortString))
-	if len(sort) == 0 {
-		sort = repo.SortBySize
-	} else if sort != repo.SortBySize && sort != repo.SortByCount {
+	sortBy := repo.SortType(strings.ToLower(sortString))
+
+	if len(sortBy) == 0 {
+		sortBy = repo.SortBySize
+	} else if sortBy != repo.SortBySize && sortBy != repo.SortByCount {
 		http.Error(w, "Invalid sort parameter, please use 'size' or 'count'", http.StatusBadRequest)
 		return
 	}
 
-	contents, err := e.exploreRepo.GetPathContents(path, sort)
+	contents, err := e.exploreRepo.GetPathContents(path, sortBy)
 	if err != nil {
 		log.Printf("Error retrieving path contents: %v", err)
 		http.Error(w, "Internal error", http.StatusInternalServerError)

--- a/internal/model/metadata.go
+++ b/internal/model/metadata.go
@@ -6,9 +6,10 @@ type Metadata struct {
 	Bucket       string    `json:"bucket" db:"bucket"`
 	Name         string    `json:"name" db:"name"`
 	Parent       string    `json:"parent" db:"parent"`
+	StorageClass string    `json:"storage_class" db:"storage_class"`
 	Size         int64     `json:"size" db:"size"`
 	Count        int64     `json:"count" db:"count"`
-	StorageClass string    `json:"storage_class" db:"storage_class"`
+	Cost         float64   `json:"cost" db:"cost"`
 	Created      time.Time `json:"created" db:"created"`
 	Updated      time.Time `json:"updated" db:"updated"`
 }

--- a/internal/repo/database.go
+++ b/internal/repo/database.go
@@ -24,16 +24,19 @@ const schema = `
 		size		INTEGER NOT NULL,
 		updated 	TIMESTAMP NOT NULL,
 		created		TIMESTAMP NOT NULL,
-		storage_class TEXT NOT NULL CHECK (storage_class IN ('STANDARD', 'NEARLINE', 'COLD', 'ARCHIVE')),
+		storage_class TEXT NOT NULL CHECK (storage_class IN ('STANDARD', 'NEARLINE', 'COLDLINE', 'ARCHIVE')),
 		PRIMARY KEY (bucket, name)
 	);
 	
 	CREATE TABLE directory (
-		bucket	TEXT NOT NULL,
-		name	TEXT NOT NULL,
-		size	INTEGER DEFAULT 0,
-		count	INTEGER DEFAULT 0,
-		parent	TEXT,
+		bucket			TEXT NOT NULL,
+		name			TEXT NOT NULL,
+		count			INTEGER DEFAULT 0,
+		size_standard 	INTEGER DEFAULT 0,
+		size_nearline 	INTEGER DEFAULT 0,
+		size_coldline	INTEGER DEFAULT 0,
+		size_archive 	INTEGER DEFAULT 0,
+		parent			TEXT,
 		FOREIGN KEY (parent) REFERENCES directory(name),
 		PRIMARY KEY (bucket, name)
 	);

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -2,6 +2,7 @@ package repo
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/GoogleCloudPlatform/gcs-metadata-server/internal/model"
 )
@@ -9,8 +10,9 @@ import (
 type SortType string
 
 const (
-	SortBySize  SortType = "size"
-	SortByCount SortType = "count"
+	SortBySize      SortType = "size"
+	SortByCount     SortType = "count"
+	defaultLocation          = LocationUS
 )
 
 type Explore struct {
@@ -27,51 +29,105 @@ func NewExploreRepository(db *Database) ExploreRepository {
 
 // GetPath retrieves all directory contents of a given path including itself
 // It excludes directories whose size is 0
-func (e *Explore) GetPathContents(path string, sort SortType) ([]*model.Metadata, error) {
+func (e *Explore) GetPathContents(path string, sortBy SortType) ([]*model.Metadata, error) {
+	type contentRow struct {
+		Name         string `db:"name"`
+		NameLength   int    `db:"name_length"`
+		StorageClass string `db:"storage_class"`
+		SizeStandard int64  `db:"size_standard"`
+		SizeNearline int64  `db:"size_nearline"`
+		SizeColdline int64  `db:"size_coldline"`
+		SizeArchive  int64  `db:"size_archive"`
+		Size         int64  `db:"size"`
+		Count        int64  `db:"count"`
+		Parent       string `db:"parent"`
+	}
+
 	if path == "/" {
 		path = "" // handle root
 	}
 
 	queryContent := `
-		SELECT name, size, parent, count -- Include self 
-		FROM directory WHERE name = $1
-		UNION ALL
-		SELECT name, size, parent, count -- Include subdirectories
+		SELECT
+			name, 
+			LENGTH(name) AS name_length,
+			size_standard, 
+			size_nearline, 
+			size_coldline, 
+			size_archive, 
+			(size_standard + 
+			size_nearline  + 
+			size_coldline  + 
+			size_archive) AS size, 
+			count,
+			'' as storage_class,
+			parent
 		FROM directory
 		WHERE
-			name LIKE $1 || '%/' AND
+			name LIKE $1 || '%' AND
 			NOT name LIKE $1 || '%/%/' AND
 			size > 0
 		UNION ALL
-		SELECT name, size, '' as parent, 0 as count -- Include subfiles
+		SELECT 
+			name, 
+			LENGTH(name) AS name_length,
+			0 as size_standard, 
+			0 as size_nearline, 
+			0 as size_coldline, 
+			0 as size_archive, 
+			size, 
+			0 as count,
+			storage_class,
+			'' as parent 
 		FROM metadata
 		WHERE
 			name LIKE $1 || '%' AND
 			NOT name LIKE $1 || '%/%'
 	`
 
-	if sort == SortByCount {
-		queryContent += " ORDER BY count DESC"
-	} else if sort == SortBySize {
-		queryContent += " ORDER BY size DESC"
-	} else {
+	if sortBy != SortByCount && sortBy != SortBySize {
 		return nil, errors.New("invalid sort parameter")
 	}
+	queryContent += fmt.Sprintf(" ORDER BY %s DESC, name_length", sortBy)
 	queryContent += " LIMIT 100;"
 
 	rows, err := e.DB.Queryx(queryContent, path)
 	if err != nil {
-		return nil, errors.New("query error: " + err.Error())
+		return nil, fmt.Errorf("query error: %w", err)
 	}
 	defer rows.Close()
 
 	var pathContents []*model.Metadata
 	for rows.Next() {
-		var metadata model.Metadata
-		if err := rows.StructScan(&metadata); err != nil {
-			return nil, errors.New("scan error: " + err.Error())
+		var row contentRow
+		if err := rows.StructScan(&row); err != nil {
+			return nil, fmt.Errorf("scan error: %w", err)
 		}
-		pathContents = append(pathContents, &metadata)
+
+		metadata := &model.Metadata{
+			Name:         row.Name,
+			Size:         row.Size,
+			Count:        row.Count,
+			StorageClass: row.StorageClass,
+			Parent:       row.Parent,
+		}
+
+		// Calculate costs of every object and directory
+		if len(metadata.StorageClass) > 0 { // object
+			cost, err := getPrice(defaultLocation, StorageClass(metadata.StorageClass), metadata.Size)
+			if err != nil {
+				return nil, err
+			}
+			metadata.Cost = cost
+		} else { // directory
+			totalCost, err := getDirectoryTotalCost(defaultLocation, row.SizeStandard, row.SizeNearline, row.SizeColdline, row.SizeArchive)
+			if err != nil {
+				return nil, err
+			}
+			metadata.Cost = totalCost
+		}
+
+		pathContents = append(pathContents, metadata)
 	}
 
 	return pathContents, nil

--- a/internal/repo/explore.go
+++ b/internal/repo/explore.go
@@ -113,14 +113,15 @@ func (e *Explore) GetPathContents(path string, sortBy SortType) ([]*model.Metada
 		}
 
 		// Calculate costs of every object and directory
+		// defaultLocation is used for all results until storing location from bucket is implemented
 		if len(metadata.StorageClass) > 0 { // object
-			cost, err := getPrice(defaultLocation, StorageClass(metadata.StorageClass), metadata.Size)
+			cost, err := getObjectCost(defaultLocation, StorageClass(metadata.StorageClass), metadata.Size)
 			if err != nil {
 				return nil, err
 			}
 			metadata.Cost = cost
 		} else { // directory
-			totalCost, err := getDirectoryTotalCost(defaultLocation, row.SizeStandard, row.SizeNearline, row.SizeColdline, row.SizeArchive)
+			totalCost, err := getDirectoryCost(defaultLocation, row.SizeStandard, row.SizeNearline, row.SizeColdline, row.SizeArchive)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/repo/metadata.go
+++ b/internal/repo/metadata.go
@@ -13,8 +13,8 @@ type Metadata struct {
 
 type MetadataRepository interface {
 	Insert(*model.Metadata) error
-	Update(bucket string, name string, size int64, updated time.Time) error
-	Delete(bucket string, name string) error
+	Update(bucket, name string, size int64, updated time.Time) error
+	Delete(bucket, name string) error
 }
 
 func NewMetadataRepository(db *Database) MetadataRepository {

--- a/internal/repo/pricing.go
+++ b/internal/repo/pricing.go
@@ -1,0 +1,92 @@
+package repo
+
+import "errors"
+
+type StorageClass string
+type Location string
+
+const (
+	StorageStandard StorageClass = "STANDARD"
+	StorageNearline StorageClass = "NEARLINE"
+	StorageColdline StorageClass = "COLDLINE"
+	StorageArchive  StorageClass = "ARCHIVE"
+
+	LocationUS   Location = "US"
+	LocationASIA Location = "ASIA"
+	LocationEU   Location = "EU"
+	LocationCA   Location = "CA"
+	LocationAU   Location = "AU"
+	LocationIN   Location = "IN"
+)
+
+const bytesPerGB = 1024 * 1024 * 1024
+
+// LocationPricing holds a general pricing per location
+// based on the most expensive region for each location
+//
+// Pricing is sourced from https://cloud.google.com/storage/pricing
+var locationPricing = map[Location]map[StorageClass]float64{
+	LocationUS: { // us-west4
+		StorageStandard: 0.0230,
+		StorageNearline: 0.0160,
+		StorageColdline: 0.0070,
+		StorageArchive:  0.0025,
+	},
+	LocationASIA: { // asia-east2
+		StorageStandard: 0.0230,
+		StorageNearline: 0.0160,
+		StorageColdline: 0.0070,
+		StorageArchive:  0.0025,
+	},
+	LocationEU: { // europe-west6
+		StorageStandard: 0.0250,
+		StorageNearline: 0.0100,
+		StorageColdline: 0.0070,
+		StorageArchive:  0.0025,
+	},
+	LocationCA: { // nothamerica-northeast1
+		StorageStandard: 0.0230,
+		StorageNearline: 0.0130,
+		StorageColdline: 0.0070,
+		StorageArchive:  0.0025,
+	},
+	LocationAU: { // australia-southeast1
+		StorageStandard: 0.0230,
+		StorageNearline: 0.0160,
+		StorageColdline: 0.0060,
+		StorageArchive:  0.0025,
+	},
+	LocationIN: { // asia-south2
+		StorageStandard: 0.0230,
+		StorageNearline: 0.0160,
+		StorageColdline: 0.0060,
+		StorageArchive:  0.0025,
+	},
+}
+
+// GetPrice returns the price for a given storage class in a specific location.
+func getPrice(location Location, storageClass StorageClass, size int64) (float64, error) {
+	price, ok := locationPricing[location][storageClass]
+	if !ok {
+		return 0, errors.New("invalid location or storage class")
+	}
+
+	sizeGb := float64(size / bytesPerGB)
+	return price * sizeGb, nil
+}
+
+func getDirectoryTotalCost(location Location, sizeStandard, sizeNearline, sizeColdline, sizeArchive int64) (float64, error) {
+	var totalCost float64 = 0
+
+	classes := []StorageClass{StorageStandard, StorageNearline, StorageColdline, StorageArchive}
+	sizes := []int64{sizeStandard, sizeNearline, sizeColdline, sizeArchive}
+
+	for i, size := range sizes {
+		cost, err := getPrice(location, classes[i], size)
+		if err != nil {
+			return 0, err
+		}
+		totalCost += cost
+	}
+	return totalCost, nil
+}

--- a/internal/seeder/seed.go
+++ b/internal/seeder/seed.go
@@ -36,7 +36,6 @@ func newMetadata(obj *storage.ObjectAttrs) *model.Metadata {
 		Created:      obj.Created,
 		Updated:      obj.Updated,
 	}
-
 }
 
 type objectIterator interface {
@@ -75,7 +74,7 @@ func (s *SeedService) insertFromIterator(it objectIterator) error {
 			log.Printf("Error inserting metadata: %v", err)
 		}
 
-		if err := s.directoryRepo.UpsertParentDirs(metadata.Bucket, metadata.Name, metadata.Size, 1); err != nil {
+		if err := s.directoryRepo.UpsertParentDirs(repo.StorageClass(metadata.StorageClass), metadata.Bucket, metadata.Name, metadata.Size, 1); err != nil {
 			log.Printf("Error upserting directories: %v", err)
 		}
 	}

--- a/internal/seeder/seed_test.go
+++ b/internal/seeder/seed_test.go
@@ -114,7 +114,7 @@ type mockDirectoryRepository struct {
 	calls int
 }
 
-func (d *mockDirectoryRepository) UpsertParentDirs(bucket string, objName string, newSize int64, newCount int64) error {
+func (d *mockDirectoryRepository) UpsertParentDirs(storageClass repo.StorageClass, bucket string, objName string, newSize int64, newCount int64) error {
 	d.calls++
 	return nil
 }


### PR DESCRIPTION
The purpose of this PR is to satisfy one of the requirements of calculating prices. This is done by dividing bytes by storage classes and then calculating depending on the region. It also refactors code that were pending of changes in previous PRs

Right now pricing is hardcoded by default but will later support single region cost estimation.

One of the potential refactors to be done is to take advantage of `UNSIGNED INTEGER` or `uint64` to support increasingly large values as we hold aggregated values. Did not include it because this PR is very large already.

## Example results from endpoint

![image](https://github.com/user-attachments/assets/3df78021-02a0-47c6-9c49-81e2e254bffb)


