### PR TITLE
/summary/ endpoint + business logic

### DIFF
--- a/internal/api/handler/explore.go
+++ b/internal/api/handler/explore.go
@@ -61,3 +61,23 @@ func (e *exploreHandler) HandleExplore(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Internal error", http.StatusInternalServerError)
 	}
 }
+
+func (e *exploreHandler) HandleSummary(w http.ResponseWriter, r *http.Request) {
+	// Normalize path param by adding slash(/) suffix if missing
+	path := r.PathValue("path")
+	if !strings.HasSuffix(path, "/") {
+		path = path + "/"
+	}
+
+	summary, err := e.exploreRepo.GetPathSummary(path)
+	if err != nil {
+		log.Printf("Error retrieving path summary: %v", err)
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Access-Control-Allow-Origin", "*") // TODO: remove in production
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(summary); err != nil {
+		http.Error(w, "Internal error", http.StatusInternalServerError)
+	}
+}

--- a/internal/api/handler/explore_test.go
+++ b/internal/api/handler/explore_test.go
@@ -81,10 +81,63 @@ func TestHandleExplore(t *testing.T) {
 	}
 }
 
+func TestHandleSummary(t *testing.T) {
+	testCases := []struct {
+		name       string
+		path       string
+		wantStatus int
+	}{
+		{
+			"Valid path with trailing slash",
+			"///mock/",
+			http.StatusOK,
+		},
+		{
+			"Valid path",
+			"mock/",
+			http.StatusOK,
+		},
+		{
+			"Root path",
+			"/",
+			http.StatusOK,
+		},
+		{
+			"Empty path",
+			"",
+			http.StatusOK,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/summary/"+tc.path, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rr := httptest.NewRecorder()
+			mockRepo := &mockExploreRepository{}
+
+			handler := NewExploreHandler(mockRepo)
+			handler.HandleSummary(rr, req)
+
+			if status := rr.Code; status != tc.wantStatus {
+				t.Errorf("status code mismatch: got %v want %v",
+					status, tc.wantStatus)
+			}
+		})
+	}
+}
+
 type mockExploreRepository struct {
 	pathContents []*model.Metadata
 }
 
 func (m *mockExploreRepository) GetPathContents(path string, sort repo.SortType) ([]*model.Metadata, error) {
 	return m.pathContents, nil
+}
+
+func (m *mockExploreRepository) GetPathSummary(path string) (*model.Summary, error) {
+	return &model.Summary{}, nil
 }

--- a/internal/api/router/router.go
+++ b/internal/api/router/router.go
@@ -14,6 +14,7 @@ func New(db *repo.Database) *http.ServeMux {
 	exploreHandler := handler.NewExploreHandler(exploreRepo)
 
 	mux.HandleFunc("GET /explore/{path...}", exploreHandler.HandleExplore)
+	mux.HandleFunc("GET /summary/{path...}", exploreHandler.HandleSummary)
 
 	return mux
 }

--- a/internal/model/summary.go
+++ b/internal/model/summary.go
@@ -1,0 +1,21 @@
+package model
+
+type Summary struct {
+	Path string `json:"path" db:"name"`
+	Cost `json:"cost"`
+	Size `json:"size"`
+}
+
+type Size struct {
+	Standard int64 `json:"standard" db:"size_standard"`
+	Nearline int64 `json:"nearline" db:"size_nearline"`
+	Coldline int64 `json:"coldline" db:"size_coldline"`
+	Archive  int64 `json:"archive" db:"size_archive"`
+}
+
+type Cost struct {
+	Standard float64 `json:"standard"`
+	Nearline float64 `json:"nearline"`
+	Coldline float64 `json:"coldline"`
+	Archive  float64 `json:"archive"`
+}

--- a/internal/repo/explore_test.go
+++ b/internal/repo/explore_test.go
@@ -142,8 +142,185 @@ func TestGetPathContents(t *testing.T) {
 					t.Errorf("Return count mismatch: got %d, want %d", got[i].Count, tc.want[i].Count)
 				}
 
-				if fmt.Sprintf("%.2f", got[i].Cost) != fmt.Sprintf("%.2f", tc.want[i].Cost) {
+				if fmt.Sprintf("%.3f", got[i].Cost) != fmt.Sprintf("%.3f", tc.want[i].Cost) {
 					t.Errorf("Return cost mismatch: got %f, want %f", got[i].Cost, tc.want[i].Cost)
+				}
+			}
+		})
+	}
+}
+
+func TestGetPathSummary(t *testing.T) {
+	db := NewDatabase(":memory:", 1)
+	db.Connect(context.Background())
+	defer db.Close()
+
+	if err := db.Setup(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := db.CreateTables(); err != nil {
+		t.Fatal(err)
+	}
+
+	exploreRepo := NewExploreRepository(db)
+	metadataRepo := NewMetadataRepository(db)
+	dirRepo := NewDirectoryRepository(db)
+
+	// Insert mock data
+	metadata := []model.Metadata{
+		{Bucket: "mock", Name: "file1", Size: 10 * bytesPerGB, Cost: 0.23, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "file2", Size: 1 * bytesPerGB, Cost: 0.023, StorageClass: "STANDARD", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "mock-1/file3", Size: 1 * bytesPerGB, Cost: 0.007, StorageClass: "COLDLINE", Created: time.Now(), Updated: time.Now()},
+		{Bucket: "mock", Name: "mock-1//file4", Size: 2 * bytesPerGB, Cost: 0.005, StorageClass: "ARCHIVE", Created: time.Now(), Updated: time.Now()},
+	}
+
+	for _, m := range metadata {
+		if err := metadataRepo.Insert(&m); err != nil {
+			t.Fatal(err)
+		}
+		if err := dirRepo.UpsertParentDirs(StorageClass(m.StorageClass), m.Bucket, m.Name, m.Size, 1); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	testCases := []struct {
+		name    string
+		path    string
+		want    *model.Summary
+		wantErr bool
+	}{
+		{
+			"Get root directory summary",
+			"/",
+			&model.Summary{
+				Path: "/",
+				Cost: model.Cost{
+					Standard: 0.253,
+					Nearline: 0,
+					Coldline: 0.007,
+					Archive:  0.005,
+				},
+				Size: model.Size{
+					Standard: 11 * bytesPerGB,
+					Nearline: 0,
+					Coldline: 1 * bytesPerGB,
+					Archive:  2 * bytesPerGB,
+				},
+			},
+			false,
+		},
+		{
+			"Get nested directory summary",
+			"mock-1/",
+			&model.Summary{
+				Path: "mock-1/",
+				Cost: model.Cost{
+					Standard: 0,
+					Nearline: 0,
+					Coldline: 0.007,
+					Archive:  0.005,
+				},
+				Size: model.Size{
+					Standard: 0,
+					Nearline: 0,
+					Coldline: 1 * bytesPerGB,
+					Archive:  2 * bytesPerGB,
+				},
+			},
+			false,
+		},
+		{
+			"Get trailing slash directory summary",
+			"mock-1//",
+			&model.Summary{
+				Path: "mock-1//",
+				Cost: model.Cost{
+					Standard: 0,
+					Nearline: 0,
+					Coldline: 0,
+					Archive:  0.005,
+				},
+				Size: model.Size{
+					Standard: 0,
+					Nearline: 0,
+					Coldline: 0,
+					Archive:  2 * bytesPerGB,
+				},
+			},
+			false,
+		},
+		{
+			"Returns empty for non-existent directory",
+			"non-existent/",
+			&model.Summary{},
+			false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := exploreRepo.GetPathSummary(tc.path)
+			if err != nil {
+				if tc.wantErr {
+					return
+				}
+				t.Fatal(err)
+			}
+
+			if tc.wantErr {
+				t.Fatalf("Expected error but did pass")
+			}
+
+			if got.Path != tc.want.Path {
+				t.Errorf("Path mismatch: got %s, want %s", got.Path, tc.want.Path)
+			}
+
+			// Compare cost and size
+			storageClasses := []StorageClass{
+				StorageStandard,
+				StorageNearline,
+				StorageColdline,
+				StorageArchive,
+			}
+
+			gotCosts := []float64{
+				got.Cost.Standard,
+				got.Cost.Nearline,
+				got.Cost.Coldline,
+				got.Cost.Archive,
+			}
+
+			wantCosts := []float64{
+				tc.want.Cost.Standard,
+				tc.want.Cost.Nearline,
+				tc.want.Cost.Coldline,
+				tc.want.Cost.Archive,
+			}
+
+			for i := range gotCosts {
+				if fmt.Sprintf("%.3f", gotCosts[i]) != fmt.Sprintf("%.3f", wantCosts[i]) {
+					t.Errorf("%s cost mismatch: got %f, want %f", storageClasses[i], gotCosts[i], wantCosts[i])
+				}
+			}
+
+			gotSizes := []int64{
+				got.Size.Standard,
+				got.Size.Nearline,
+				got.Size.Coldline,
+				got.Size.Archive,
+			}
+
+			wantSizes := []int64{
+				tc.want.Size.Standard,
+				tc.want.Size.Nearline,
+				tc.want.Size.Coldline,
+				tc.want.Size.Archive,
+			}
+
+			for i := range gotSizes {
+				if gotSizes[i] != wantSizes[i] {
+					t.Errorf("%s size mismatch: got %d, want %d", storageClasses[i], gotSizes[i], wantSizes[i])
 				}
 			}
 		})


### PR DESCRIPTION
The purpose of this PR is to create the `/summary/` endpoint which will give a detailed breakdown of a path including its size divided by storage class and pricing.

The following PR will add this endpoint to the UI.

## Changes

* Created new endpoint `/summary/:path`
* Added business logic to fetch and compute pricing based on path results
* Added `summary` model
* Added unit tests to all new components with expected behavior

## Response schema
```
GET /summary/:path
title: string
cost: Cost{}
size: Size{}
```

## Response example
![image](https://github.com/user-attachments/assets/a0f5272e-556b-459b-b4a1-43cbbe1de1ad)
