### PR TITLE
Added summary endpoint + UI

### DIFF
--- a/ui/src/app/app.component.css
+++ b/ui/src/app/app.component.css
@@ -5,8 +5,12 @@
 
 html,
 body {
-  width: 100%;
-  height: 100%;
+  width: 100vw;
+  height: 100vh;
+
+  max-width: 100vw;
+  max-height: 100vh;
+
   margin: 0;
   padding: 0;
   box-sizing: border-box;
@@ -33,11 +37,14 @@ body {
 }
 
 .summary {
-  flex: 1;
+  width: 25vw;
+  max-width: 25vw;
 }
 
 .viewer {
   flex: 3;
+  width: 70vw;
+  min-width: 70vw;
 }
 
 .header {
@@ -46,7 +53,8 @@ body {
 }
 
 .header-left {
-  flex: 1;
+  width: 25vw;
+  max-width: 25vw;
 }
 
 .header-search {

--- a/ui/src/app/pipes/size.pipe.spec.ts
+++ b/ui/src/app/pipes/size.pipe.spec.ts
@@ -1,0 +1,8 @@
+import { SizePipe} from './size.pipe';
+
+describe('SizePipePipe', () => {
+  it('create an instance', () => {
+    const pipe = new SizePipe();
+    expect(pipe).toBeTruthy();
+  });
+});

--- a/ui/src/app/pipes/size.pipe.ts
+++ b/ui/src/app/pipes/size.pipe.ts
@@ -1,0 +1,19 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'size',
+  standalone: true
+})
+export class SizePipe implements PipeTransform {
+  transform(bytes: number): string {
+    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+    let i = 0;
+
+    while (bytes >= 1024 && i < units.length - 1) {
+      bytes /= 1024;
+      i++;
+    }
+
+    return `${bytes.toFixed(1)} ${units[i]}`;
+  }
+}

--- a/ui/src/app/services/api-request.ts
+++ b/ui/src/app/services/api-request.ts
@@ -1,0 +1,21 @@
+import { environment } from '../../environments/environment';
+
+/**
+ * requestJson is a helper function to fetch and return a Json with proper error handling
+ * @param path endpoint in which to create request
+ * @returns Json promise of response
+ */
+export async function requestJson(path: string): Promise<any> {
+  // const url = new URL(path, environment.apiBaseUrl);
+  const response = await fetch(`${environment.apiBaseUrl}${path}`);
+
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+
+  if (!response.body) {
+    throw new Error('Response body is empty');
+  }
+
+  return await response.json();
+}

--- a/ui/src/app/summary/summary.component.css
+++ b/ui/src/app/summary/summary.component.css
@@ -2,9 +2,22 @@ mat-card {
   height: 100%;
 }
 
-mat-card-header {
-  font-size: 1.5rem;
-  margin: 0 auto;
-  padding-bottom: 1rem;
-  text-align: center;
+mat-card-header::ng-deep {
+  display:flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+h3 {
+  font-size: 1.2rem;
+  margin: 0;
+}
+
+.path {
+  max-width: 100%;
+
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+  direction: rtl;
 }

--- a/ui/src/app/summary/summary.component.html
+++ b/ui/src/app/summary/summary.component.html
@@ -1,5 +1,15 @@
 <mat-card appearance="outlined">
-  <mat-card-header> Cost breakdown in<br />{{ path }} </mat-card-header>
+  <mat-card-header>
+    <h3 class="title">Cost breakdown in</h3>
+    <h3 class="path">{{ path }}</h3>
+  </mat-card-header>
   <mat-card-content>
+    @if (sizes && costs) {
+    <div *ngFor="let key of rows">
+      <h3>{{ key[0].toUpperCase() + key.slice(1) }}</h3>
+      <p>Size: {{ sizes[key] | size }}</p>
+      <p>Cost: ${{ costs[key].toFixed(2) }}</p>
+    </div>
+    }
   </mat-card-content>
 </mat-card>

--- a/ui/src/app/summary/summary.component.html
+++ b/ui/src/app/summary/summary.component.html
@@ -6,7 +6,7 @@
   <mat-card-content>
     @if (sizes && costs) {
     <div *ngFor="let key of rows">
-      <h3>{{ key[0].toUpperCase() + key.slice(1) }}</h3>
+      <h3>{{ capitalize(key) }}</h3>
       <p>Size: {{ sizes[key] | size }}</p>
       <p>Cost: ${{ costs[key].toFixed(2) }}</p>
     </div>

--- a/ui/src/app/summary/summary.component.ts
+++ b/ui/src/app/summary/summary.component.ts
@@ -1,13 +1,47 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { MatCardModule } from '@angular/material/card';
+import { ExploreService } from '../services/explore.service';
+import { KeyValuePipe, NgFor, NgIf } from '@angular/common';
+import { SizePipe } from '../pipes/size.pipe';
 
 @Component({
   selector: 'app-summary',
   standalone: true,
-  imports: [MatCardModule],
+  imports: [MatCardModule, NgFor, KeyValuePipe, NgIf, SizePipe],
   templateUrl: './summary.component.html',
   styleUrl: './summary.component.css',
 })
-export class SummaryComponent {
+export class SummaryComponent implements OnChanges {
   @Input({ required: true }) path!: string;
+
+  rows = ['standard', 'nearline', 'coldline', 'archive'];
+  sizes!: any;
+  costs!: any;
+
+  constructor(private exploreService: ExploreService) {}
+
+  ngOnChanges(changes: SimpleChanges): void {
+    if (
+      changes['path'] &&
+      changes['path'].currentValue &&
+      changes['path'].currentValue !== changes['path'].previousValue
+    ) {
+      this.fetchSummary();
+    }
+  }
+
+  async fetchSummary() {
+    try {
+      const res = await this.exploreService.getSummary(this.path);
+
+      this.sizes = res.size;
+      this.costs = res.cost;
+    } catch (error) {
+      console.error(`Error fetching summary for path ${this.path}: ${error}`);
+    }
+  }
+
+  capitalize(str: string) {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  }
 }

--- a/ui/src/app/viewer/table/table.component.html
+++ b/ui/src/app/viewer/table/table.component.html
@@ -25,7 +25,7 @@
 
   <ng-container matColumnDef="size">
     <th mat-header-cell *matHeaderCellDef>Size</th>
-    <td mat-cell *matCellDef="let element">{{ formatBytes(element.size) }}</td>
+    <td mat-cell *matCellDef="let element">{{ element.size | size }}</td>
   </ng-container>
 
   <ng-container matColumnDef="count">

--- a/ui/src/app/viewer/table/table.component.ts
+++ b/ui/src/app/viewer/table/table.component.ts
@@ -10,11 +10,12 @@ import { MetadataObject } from '../../services/explore.service';
 import { MatTableModule } from '@angular/material/table';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
 import { MatIconModule } from '@angular/material/icon';
+import { SizePipe } from '../../pipes/size.pipe';
 
 @Component({
   selector: 'app-table',
   standalone: true,
-  imports: [MatTableModule, MatProgressSpinnerModule, MatIconModule],
+  imports: [MatTableModule, MatProgressSpinnerModule, MatIconModule, SizePipe],
   templateUrl: './table.component.html',
   styleUrl: './table.component.css',
 })
@@ -43,17 +44,5 @@ export class TableComponent implements OnChanges {
     if (changes['directoryList$']) {
       this.directoryList$ = changes['directoryList$'].currentValue;
     }
-  }
-
-  formatBytes(bytes: number): string {
-    const units = ['B', 'KB', 'MB', 'GB', 'TB'];
-    let i = 0;
-
-    while (bytes >= 1024 && i < units.length - 1) {
-      bytes /= 1024;
-      i++;
-    }
-
-    return `${bytes.toFixed(1)} ${units[i]}`;
   }
 }

--- a/ui/src/app/viewer/viewer.component.html
+++ b/ui/src/app/viewer/viewer.component.html
@@ -1,6 +1,6 @@
 <mat-card class="table-card" appearance="outlined">
   <mat-card-header>
-    <span class="title">{{ currentPath }}</span>
+    <h3 class="title">{{ currentPath }}</h3>
   </mat-card-header>
   <mat-card-content class="table-container">
     @if (view == "directory") {


### PR DESCRIPTION
In this pull request I add all the changes done in the back-end to include summaries divided by storage classes as per wireframe.

I also add some CSS fixes for issues that I found when navigating very large directory names and organized the code by making use of pipes instead of function `formatBytes()`

## Showcase
![image](https://github.com/user-attachments/assets/d66e3493-5585-4b1e-87b6-5776ce19f3be)
