### PR TITLE
Added indexing, refactored /explore/ query and schema

### DIFF
--- a/cmd/seeder/main.go
+++ b/cmd/seeder/main.go
@@ -65,5 +65,8 @@ func main() {
 		log.Fatalf("Error while seeding: %v\n", err)
 	}
 
+	if err := db.CreateIndexes(); err != nil {
+		log.Fatalf("Error creating indexes: %v\n", err)
+	}
 	log.Printf("Seeding completed. Duration: %v\n", time.Since(start))
 }

--- a/internal/repo/metadata.go
+++ b/internal/repo/metadata.go
@@ -24,8 +24,8 @@ func NewMetadataRepository(db *Database) MetadataRepository {
 func (m *Metadata) Insert(obj *model.Metadata) error {
 	query := `
 		INSERT INTO metadata 
-		(bucket, name, size, storage_class, created, updated)	
-		VALUES (?, ?, ?, ?, ?, ?);
+		(bucket, name, size, parent, storage_class, created, updated)	
+		VALUES (?, ?, ?, ?, ?, ?, ?);
 	`
 
 	if len(obj.Bucket) == 0 || len(obj.Name) == 0 {
@@ -36,6 +36,7 @@ func (m *Metadata) Insert(obj *model.Metadata) error {
 		obj.Bucket,
 		obj.Name,
 		obj.Size,
+		getParentDir(obj.Name),
 		obj.StorageClass,
 		obj.Created,
 		obj.Updated); err != nil {


### PR DESCRIPTION
This PR adds:

* Added `parent` foreign key for `directory(name)`
* Indexing after seeding + vacuuming to remove extra space after seeding (this should be done periodically in the future)
* Used `parent` column to find directory contents instead of `LIKE` operator

The purpose of this Pull Request is to refactor `/explore/` query as after doing some testing with larger sets of metadata (~1M objects), I identified `SELECT` queries to take over 200ms which meant the query was not feasible at scale.

In efforts to improve this query, I decided to rethink the implementation and simplify it by taking advantage of the one-to-many data structure by using column `parent` on both `directory` and `metadata`. This enabled the use of indexes as the `LIKE` operator on most cases tend to scan instead of using an index.

The results brought down this query from ~200ms with 1M objects to ~1ms with ~2M objects which manages larger database metadata to be faster exploring at the cost of some more overhead on the seeding process which is our objective.

### Database used for testing purposes

![image](https://github.com/user-attachments/assets/a5bc494e-a66c-4668-9e13-8b4da0e6f421)

### Before, no indexing, using `LIKE` operator 

![image](https://github.com/user-attachments/assets/5a98afae-672e-43cd-8f55-d87017c654b1)

### After, using indexing and `parent` as the way to find directory's direct children

![image](https://github.com/user-attachments/assets/615b55ec-91ac-4266-a9fb-568828d003b3)