### PR TITLE
Add UpsertArchiveParentDirs for object versioning updates

### DIFF
--- a/internal/model/directory.go
+++ b/internal/model/directory.go
@@ -1,8 +1,11 @@
 package model
 
 type Directory struct {
-	Bucket string `json:"bucket" db:"bucket"`
-	Name   string `json:"name" db:"name"`
-	Size   int64  `json:"size" db:"size"`
-	Count  int64  `json:"count" db:"count"`
+	Bucket       string `json:"bucket" db:"bucket"`
+	Name         string `json:"name" db:"name"`
+	SizeStandard int64  `db:"size_standard"`
+	SizeNearline int64  `db:"size_nearline"`
+	SizeColdline int64  `db:"size_coldline"`
+	SizeArchive  int64  `db:"size_archive"`
+	Count        int64  `json:"count" db:"count"`
 }

--- a/internal/repo/directory.go
+++ b/internal/repo/directory.go
@@ -82,10 +82,7 @@ func (d *Directory) UpsertArchiveParentDirs(oldStorageClass StorageClass, newSto
 		dirName = getParentDir(dirName)
 	}
 
-	if err := tx.Commit(); err != nil {
-		return err
-	}
-	return nil
+	return tx.Commit()
 }
 
 // UpsertParentDirs updates all parent directories of an object name in one transaction

--- a/internal/repo/directory_test.go
+++ b/internal/repo/directory_test.go
@@ -37,21 +37,126 @@ func TestGetParentDir(t *testing.T) {
 	}
 }
 
-func TestUpsertParentDirs(t *testing.T) {
-	type dir struct {
-		Name         string
-		SizeStandard int64 `db:"size_standard"`
-		SizeNearline int64 `db:"size_nearline"`
-		SizeColdline int64 `db:"size_coldline"`
-		SizeArchive  int64 `db:"size_archive"`
-		Count        int64
+func TestUpsertArchiveParentDirs(t *testing.T) {
+	testCases := []struct {
+		name            string
+		metadataInDB    []*model.Metadata
+		oldStorageClass StorageClass
+		newStorageClass StorageClass
+		bucket          string
+		objName         string
+		size            int64
+		wantDirs        []*model.Directory
+		wantErr         bool
+	}{
+		{
+			"Updates existing directory",
+			[]*model.Metadata{
+				{Bucket: "mock", Name: "mock-1/mock-2/file1", Size: 1, StorageClass: "STANDARD"},
+			},
+			StorageStandard,
+			StorageNearline,
+			"mock",
+			"mock-1/mock-2/file1",
+			1,
+			[]*model.Directory{
+				{Name: "/", SizeStandard: 0, SizeNearline: 1, SizeColdline: 0, SizeArchive: 0, Count: 1},
+				{Name: "mock-1/", SizeStandard: 0, SizeNearline: 1, SizeColdline: 0, SizeArchive: 0, Count: 1},
+				{Name: "mock-1/mock-2/", SizeStandard: 0, SizeNearline: 1, SizeColdline: 0, SizeArchive: 0, Count: 1},
+			},
+			false,
+		},
+		{
+			"Fails with empty bucket",
+			[]*model.Metadata{},
+			StorageStandard,
+			StorageNearline,
+			"",
+			"mock-1/mock-2/file1",
+			1,
+			nil,
+			true,
+		},
+		{
+			"Fails with empty object name",
+			[]*model.Metadata{},
+			StorageStandard,
+			StorageNearline,
+			"mock",
+			"",
+			1,
+			nil,
+			true,
+		},
 	}
 
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			db := NewDatabase(":memory:", 1)
+			db.Connect(context.Background())
+			defer db.Close()
+
+			if err := db.Setup(); err != nil {
+				t.Fatal(err)
+			}
+
+			if err := db.CreateTables(); err != nil {
+				t.Fatal(err)
+			}
+
+			dirRepo := NewDirectoryRepository(db)
+
+			for _, m := range tc.metadataInDB {
+				if err := dirRepo.UpsertParentDirs(StorageClass(m.StorageClass), m.Bucket, m.Name, m.Size, 1); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			if err := dirRepo.UpsertArchiveParentDirs(tc.oldStorageClass, tc.newStorageClass, tc.bucket, tc.objName, tc.size); err != nil {
+				if tc.wantErr {
+					return
+				}
+				t.Fatal(err)
+			}
+
+			for _, wantDir := range tc.wantDirs {
+				var gotDir model.Directory
+				err := db.QueryRowx(`SELECT count, size_standard, size_nearline, size_coldline, size_archive 
+									FROM directory WHERE name = ?`, wantDir.Name).StructScan(&gotDir)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if gotDir.Count != wantDir.Count {
+					t.Errorf("Directory count mismatch: got %d, want %d", gotDir.Count, wantDir.Count)
+				}
+
+				if gotDir.SizeStandard != wantDir.SizeStandard {
+					t.Errorf("Directory size standard mismatch: got %d, want %d", gotDir.SizeStandard, wantDir.SizeStandard)
+				}
+
+				if gotDir.SizeNearline != wantDir.SizeNearline {
+					t.Errorf("Directory size nearline mismatch: got %d, want %d", gotDir.SizeNearline, wantDir.SizeNearline)
+				}
+
+				if gotDir.SizeColdline != wantDir.SizeColdline {
+					t.Errorf("Directory size coldline mismatch: got %d, want %d", gotDir.SizeColdline, wantDir.SizeColdline)
+				}
+
+				if gotDir.SizeArchive != wantDir.SizeArchive {
+					t.Errorf("Directory size archive mismatch: got %d, want %d", gotDir.SizeArchive, wantDir.SizeArchive)
+				}
+			}
+		})
+	}
+}
+
+func TestUpsertParentDirs(t *testing.T) {
 	testCases := []struct {
 		name         string
 		metadataInDB []*model.Metadata
 		in           *model.Metadata
-		wantDirs     []*dir
+		wantDirs     []*model.Directory
 		wantErr      bool
 	}{
 		{
@@ -61,7 +166,7 @@ func TestUpsertParentDirs(t *testing.T) {
 				{Bucket: "mock", Name: "mock-1/mock-2/file2", Size: 2, StorageClass: "NEARLINE"},
 			},
 			&model.Metadata{Bucket: "mock", Name: "file3", Size: 3, StorageClass: "COLDLINE"},
-			[]*dir{
+			[]*model.Directory{
 				{Name: "/", SizeStandard: 1, SizeNearline: 2, SizeColdline: 3, Count: 3},
 				{Name: "mock-1/", SizeStandard: 1, SizeNearline: 2, SizeColdline: 0, Count: 2},
 				{Name: "mock-1/mock-2/", SizeStandard: 1, SizeNearline: 2, SizeColdline: 0, Count: 2},
@@ -76,7 +181,7 @@ func TestUpsertParentDirs(t *testing.T) {
 				{Bucket: "mock", Name: "file3", Size: 3, StorageClass: "STANDARD"},
 			},
 			&model.Metadata{Bucket: "mock", Name: "mock-1/file4", Size: 1, StorageClass: "ARCHIVE"},
-			[]*dir{
+			[]*model.Directory{
 				{Name: "mock-1/", SizeStandard: 1, SizeNearline: 2, SizeArchive: 1, Count: 3},
 			},
 			false,
@@ -88,7 +193,7 @@ func TestUpsertParentDirs(t *testing.T) {
 				{Bucket: "mock", Name: "mock-1/mock-2/file2", Size: 2, StorageClass: "NEARLINE"},
 			},
 			&model.Metadata{Bucket: "mock", Name: "file3", Size: 3, StorageClass: "COLDLINE"},
-			[]*dir{
+			[]*model.Directory{
 				{Name: "/", SizeStandard: 1, SizeNearline: 2, SizeColdline: 3, Count: 3},
 			},
 			false,
@@ -99,7 +204,7 @@ func TestUpsertParentDirs(t *testing.T) {
 				{Bucket: "mock", Name: "///file", Size: 3, StorageClass: "STANDARD"},
 			},
 			&model.Metadata{Bucket: "mock", Name: "//test/file2", Size: 3, StorageClass: "NEARLINE"},
-			[]*dir{
+			[]*model.Directory{
 				{Name: "//test/", SizeNearline: 3, Count: 1},
 			},
 			false,
@@ -147,7 +252,7 @@ func TestUpsertParentDirs(t *testing.T) {
 			}
 
 			for _, wantDir := range tc.wantDirs {
-				var gotDir dir
+				var gotDir model.Directory
 				err := db.QueryRowx(`SELECT count, size_standard, size_nearline, size_coldline, size_archive 
 									FROM directory WHERE name = ?`, wantDir.Name).StructScan(&gotDir)
 				if err != nil {


### PR DESCRIPTION
This PR adds `UpsertArchiveParentDirs()` which will serve to transfer sizes which are divided in between classes to one another which will be the main operation for `OBJECT_ARCHIVE` events which are only invoked for buckets with [object versioning](https://cloud.google.com/storage/docs/object-versioning) enabled.

This function is implemented for the upcoming subscriber service. It is necessary to upsert as pub/sub messages are not ordered for [multi-region buckets](https://cloud.google.com/pubsub/docs/ordering) and when receiving a large stream of messages we have to act gracefully against new/existing metadata despite order whenever necessary.