### PR TITLE
Remove sql.ErrNoRows skip on MetadataRepo.Get()

### DIFF
--- a/internal/repo/metadata.go
+++ b/internal/repo/metadata.go
@@ -1,7 +1,6 @@
 package repo
 
 import (
-	"database/sql"
 	"errors"
 	"time"
 
@@ -33,7 +32,7 @@ func (m *Metadata) Get(bucket, name string) (*model.Metadata, error) {
 
 	// Select record and ignore empty results for services not to depend on database errors
 	var metadata model.Metadata
-	if err := m.DB.Get(&metadata, query, bucket, name); err != nil && err != sql.ErrNoRows {
+	if err := m.DB.Get(&metadata, query, bucket, name); err != nil {
 		return nil, err
 	}
 	return &metadata, nil

--- a/internal/repo/metadata_test.go
+++ b/internal/repo/metadata_test.go
@@ -35,22 +35,22 @@ func TestGetMetadata(t *testing.T) {
 	}
 
 	testCases := []struct {
-		name      string
-		bucket    string
-		objName   string
-		wantEmpty bool
+		name    string
+		bucket  string
+		objName string
+		wantErr bool
 	}{
 		{
-			name:      "Get existing metadata",
-			bucket:    "mock",
-			objName:   "mock-object",
-			wantEmpty: false,
+			name:    "Get existing metadata",
+			bucket:  "mock",
+			objName: "mock-object",
+			wantErr: false,
 		},
 		{
-			name:      "non-existent object should return empty object",
-			bucket:    "fake",
-			objName:   "fake",
-			wantEmpty: true,
+			name:    "Fails when getting non-existent metadata",
+			bucket:  "fake",
+			objName: "fake",
+			wantErr: true,
 		},
 	}
 
@@ -58,13 +58,17 @@ func TestGetMetadata(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			got, err := metadataRepo.Get(tc.bucket, tc.objName)
 			if err != nil {
+				if tc.wantErr {
+					return
+				}
 				t.Fatal(err)
 			}
 
+			if tc.wantErr {
+				t.Fatal("Expected error but did pass")
+			}
+
 			if got.Name != tc.objName {
-				if len(got.Name) == 0 && tc.wantEmpty {
-					return
-				}
 				t.Fatalf("got %s, want %s", got.Name, tc.objName)
 			}
 		})


### PR DESCRIPTION
In this PR I remove the skip of `sql.ErrNoRows` error as it ended up causing more complexity when checking if there are results. 

This skip was mainly to prevent other packages to import `database/sql` but it ends up being more complex unnecessarily and the objective is to have something simple and predictable.