### PR TITLE
Added treemap onClick events

### DIFF
--- a/ui/src/app/summary-bucket/summary-bucket.component.html
+++ b/ui/src/app/summary-bucket/summary-bucket.component.html
@@ -1,5 +1,4 @@
 <mat-card appearance="outlined">
-  <mat-card-header> Bucket name </mat-card-header>
   <mat-card-content>
   </mat-card-content>
 </mat-card>

--- a/ui/src/app/viewer/treemap/treemap.component.ts
+++ b/ui/src/app/viewer/treemap/treemap.component.ts
@@ -1,5 +1,6 @@
 import {
   AfterViewInit,
+  ChangeDetectionStrategy,
   Component,
   EventEmitter,
   Input,
@@ -28,6 +29,7 @@ export class TreemapComponent implements OnChanges, AfterViewInit {
   @ViewChild('chart') chart!: GoogleChartComponent;
 
   @Output() newPathEvent = new EventEmitter<string>();
+  @Output() onBackEvent = new EventEmitter<string>();
 
   cols = [
     { type: 'string', id: 'name' },
@@ -59,7 +61,7 @@ export class TreemapComponent implements OnChanges, AfterViewInit {
       google.visualization.events.addListener(
         this.chart.chartWrapper.getChart(),
         'select',
-        this.handleChartClick.bind(this),
+        this.handleChartClick.bind(this)
       );
     }
   }
@@ -69,13 +71,15 @@ export class TreemapComponent implements OnChanges, AfterViewInit {
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes['directoryList$']) {
-      this.refreshTreeMapData(changes['directoryList$'].currentValue);
-    }
+    console.log('refreshing');
+    this.refreshTreeMapData(changes['directoryList$'].currentValue);
   }
 
   onSelect(event: any) {
-    console.log('event is:', event);
+    const row = event.selection[0].row;
+    const selectedDirName = this.data[row][0] as string;
+
+    this.newPathEvent.emit(selectedDirName);
   }
 
   refreshTreeMapData(newDirs: MetadataObject[]) {
@@ -87,19 +91,30 @@ export class TreemapComponent implements OnChanges, AfterViewInit {
       .slice(4)
       .reduce((count, dir) => count + dir.count, 0);
 
+    const parentDir = newDirs[0].name;
+
     const otherDir: MetadataObject = {
       name: 'Other',
       count: 0,
-      parent: '/',
+      parent: parentDir,
       size: otherSize,
     };
+
+    // get the children of other
+    const otherChildren = newDirs
+      .slice(4)
+      .map((dir) => {
+        dir.parent = otherDir.name
+        return [dir.name, dir.parent, 0.1]
+      });
 
     const top3Sizes = [60, 25, 10];
 
     this.data = [
-      [newDirs[0].name, null, newDirs[0].size],
-      ...top3.map((dir, i) => [dir.name, '/', top3Sizes[i]] as Row),
-      [otherDir.name, '/', 5] as Row,
+      [newDirs[0].name, null, newDirs[0].size], // parent
+      ...top3.map((dir, i) => [dir.name, parentDir, top3Sizes[i]] as Row), // top 3 directories in size
+      [otherDir.name, parentDir, 5] as Row, // group of other directories
+      ...otherChildren,
     ];
   }
 }

--- a/ui/src/app/viewer/viewer.component.css
+++ b/ui/src/app/viewer/viewer.component.css
@@ -27,15 +27,15 @@ mat-card-content {
   direction: rtl;
 }
 
-.refresh-icon {
+.icon {
   cursor:pointer;
 }
 
-.refresh-icon:hover {
+.icon:hover {
   transform: scale(1.1);
   transition: transform 0.1s;
 }
 
-.refresh-icon:active {
+.icon:active {
   transform: scale(0.9);
 }

--- a/ui/src/app/viewer/viewer.component.html
+++ b/ui/src/app/viewer/viewer.component.html
@@ -1,7 +1,14 @@
 <mat-card class="table-card" appearance="outlined">
   <mat-card-header>
     <mat-icon
-      class="refresh-icon"
+      class="icon"
+      aria-label="arrow back"
+      aria-hidden="false"
+      fontIcon="arrow_back"
+      (click)="goBack()"
+    />
+    <mat-icon
+      class="icon"
       aria-label="refresh icon"
       aria-hidden="false"
       fontIcon="refresh"
@@ -21,6 +28,7 @@
     <app-treemap
       [directoryList$]="directoryList$"
       (newPathEvent)="goTo($event)"
+      (onBackEvent)="goBack()"
     />
     }
   </mat-card-content>


### PR DESCRIPTION
In this pull request I add changes to add the ability to drill down in Treemap directories and also show the children of "Other" block. The sizes are arbitrary as the chart just adds proportions on how big in comparison of other objects